### PR TITLE
Fixing download link in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ REPO_URL = 'https://github.com/hanpeter/make-project'
 
 # Github will generate a tarball as long as you tag your releases, so don't
 # forget to tag!
-DOWNLOAD_URL = ''.join((REPO_URL, '/tarball/release/', VERSION))
+DOWNLOAD_URL = ''.join((REPO_URL, '/tarball/', VERSION))
 
 
 setup(


### PR DESCRIPTION
## What does this PR do?

This is a hot fix PR to fix `DOWNLOAD_URL` in `setup.py`.

## Why is this change being made?

Tags are named after the version, with no prefix. Thus, the `DOWNLOAD_URL` does not work properly.

## How was this tested? How can the reviewer verify your testing?

The change was tested manually on the development environment.